### PR TITLE
Add prometheus metrics for pack-left percent-full

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 78df86484a8c0ff02f908bb8f09e3dc1bf0d4e089a153308d5b60ec56b124a0b
-updated: 2018-10-04T13:44:15.104753377-06:00
+hash: 89f9cc3385cffe37fb7cf7ab6352fbcb5b856511ce1408f77d7f4b53d1168b4c
+updated: 2018-10-18T15:45:20.48698432-06:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -79,9 +79,11 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/op/go-logging
-  version: 970db520ece77730c7e4724c61121037378659d9
+  version: b2cb9fa56473e98db8caba80237377e83fe44db5
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
+- name: github.com/prometheus/client_golang
+  version: 1cafe34db7fdec6022e17e00e1c1ea501022f3e4
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
@@ -202,6 +204,7 @@ imports:
   version: 2ae454230481a7cb5544325e12ad7658ecccd19b
   subpackages:
   - discovery
+  - discovery/fake
   - kubernetes
   - kubernetes/scheme
   - kubernetes/typed/admissionregistration/v1alpha1
@@ -231,6 +234,7 @@ imports:
   - pkg/version
   - rest
   - rest/watch
+  - testing
   - tools/auth
   - tools/cache
   - tools/clientcmd

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,10 +6,11 @@ import:
   version: ^2.2.6
 - package: k8s.io/code-generator
   version: 961bc077103364eb5bda2c40e2b560d068c9a8c6
-
 - package: k8s.io/client-go
   version: v5.0.1
 - package: k8s.io/apimachinery
   version: kubernetes-1.8.0
 - package: k8s.io/api
   version: kubernetes-1.8.1
+- package: github.com/prometheus/client_golang
+  version: v0.9.0

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	valetclient "github.com/domoinc/kube-valet/pkg/client/clientset/versioned"
 	"github.com/op/go-logging"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -125,6 +127,9 @@ func main() {
 		},
 		LoggingBackend: backend1Leveled,
 	})
+
+	http.Handle("/metrics", promhttp.Handler())
+	go http.ListenAndServe(":8080", nil)
 
 	// Run the kube valet
 	kd.Run()

--- a/pkg/controller/podassignment/manager.go
+++ b/pkg/controller/podassignment/manager.go
@@ -54,7 +54,7 @@ func (m *Manager) GetPodAssignmentsScheduling(pod *corev1.Pod) []*assignmentsv1a
 			r = append(r, obj.(*assignmentsv1alpha1.ClusterPodAssignmentRule).Spec.Scheduling.DeepCopy())
 		}
 	}); err != nil {
-		m.log.Error(err)
+		m.log.Errorf("Unable to get Non-Namespaced pod assignment scheduling %s", err)
 	}
 
 	// Namespaced, get via indexer
@@ -63,7 +63,7 @@ func (m *Manager) GetPodAssignmentsScheduling(pod *corev1.Pod) []*assignmentsv1a
 			r = append(r, obj.(*assignmentsv1alpha1.PodAssignmentRule).Spec.Scheduling.DeepCopy())
 		}
 	}); err != nil {
-		m.log.Error(err)
+		m.log.Errorf("Unable to get Namespaced pod assignment scheduling %s", err)
 	}
 
 	return r

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -1,0 +1,30 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Registry struct {
+	packLeftPercentFullByNag map[string]*prometheus.GaugeVec
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		packLeftPercentFullByNag: make(map[string]*prometheus.GaugeVec),
+	}
+}
+
+func (r *Registry) GetPackLeftPercentFull(name string) *prometheus.GaugeVec {
+	if _, ok := r.packLeftPercentFullByNag[name]; !ok {
+		r.packLeftPercentFullByNag[name] = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name:        "kubevalet_packleft_full_percent",
+			ConstLabels: prometheus.Labels{"node_assignment_group": name},
+		}, []string{
+			"node_assignment",
+			"node_name",
+			"pack_left_state",
+		})
+		prometheus.MustRegister(r.packLeftPercentFullByNag[name])
+	}
+	return r.packLeftPercentFullByNag[name]
+}


### PR DESCRIPTION
- registry needs to hold on to references that it creates
- reset metrics every rebalance (metrics will change and we don't want old labels hanging around)

@carsonoid 

Need to do some more testing to ensure when rebalance takes place old metrics don't hang around, but wanted to get some early feedback on the design.