### PR TITLE
 Remove unschedulable node from pack-left balancing

### DIFF
--- a/pkg/controller/scheduling/packleft/controller.go
+++ b/pkg/controller/scheduling/packleft/controller.go
@@ -69,7 +69,7 @@ func (plc *Controller) OnAddNode(node *corev1.Node) {
 
 // OnUpdateNode when a node is updated rebalance all the nags that point to it
 func (plc *Controller) OnUpdateNode(oldNode *corev1.Node, newNode *corev1.Node) {
-	if utils.NodeTargetingHasChanged(oldNode, newNode) {
+	if utils.NodeTargetingHasChanged(oldNode, newNode) || (NodeCanBeBalanced(oldNode) != NodeCanBeBalanced(newNode)) {
 		plc.log.Debugf("PackLeft: Node %s has updated targetable attributes. Requeueing all Nags", oldNode.GetName())
 		plc.queueAllNags()
 	}


### PR DESCRIPTION
Nodes that are unschedulable should not be considered in pack-left scheduling 
Nodes should also be cleaned up if they are unschedulable.

@carsonoid 