### PR TITLE
Remove restartPolicy from TLS Job spec

### DIFF
--- a/helm/templates/tls-setup.yaml
+++ b/helm/templates/tls-setup.yaml
@@ -129,7 +129,6 @@ spec:
   completions: 1
   parallelism: 1
   backoffLimit: 1
-  restartPolicy: Never
   template:
     spec:
       serviceAccountName: tls-bootstrap


### PR DESCRIPTION
restartPolicy isn't part of the batch/v1 Job spec